### PR TITLE
Public relay name change

### DIFF
--- a/app/src/main/java/kt/nostr/nosky_compose/main_backend/NostrService.kt
+++ b/app/src/main/java/kt/nostr/nosky_compose/main_backend/NostrService.kt
@@ -144,7 +144,7 @@ object NostrService {
         nostrClient.connect(mutableListOf(filter),
        //    relays = arrayOf(Relay("wss://relay.nostr.info"))
 //                //Relay("wss://relay.damus.io"),
-//                Relay("wss://nostr.bitcoiner.social"),
+//                Relay("wss://offchain.pub"),
 //                Relay("wss://nostr.rocks"),
 //                Relay("wss//nostr-pub.semisol.dev"))
             )


### PR DESCRIPTION
nostr.bitcoiner.social -> offchain.pub

note1zpgy9f8tlwdwhhwtzy50vpl72qkunzhmy57p4f5xaf8h57pfvwpschwe74

> Before I deployed the new pay-to-relay server, I ran a public relay under a "nostr" subdomain. I've since renamed my public relay to wss://offchain.pub. Much cooler name. Better represents how nostr isn't something this domain handles on the side, it's the primary purpose. Raison d'etre.
> 
> Both offchain.pub and the "nostr" subdomain will work concurrently for awhile, pointing to the same public relay server. But I'll eventually deprecate the "nostr" subdomain and redirect requests to the new offchain.pub name.